### PR TITLE
Add GHCR action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: Build and Push to GHCR
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  get_tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine deployment tag
+        id: deployment_tag
+        run: |
+          if [[ '${{ github.ref_type }}' == 'tag' ]]; then
+            export tag=${{ github.ref_name }}
+            echo "version tag is $tag"
+            echo "id=$tag" >> $GITHUB_OUTPUT
+          else
+            export tag=latest
+            echo "version tag is $tag"
+            echo "id=$tag" >> $GITHUB_OUTPUT
+          fi
+    outputs:
+      deployment_tag: ${{ steps.deployment_tag.outputs.id }}
+
+  build-and-push:
+    needs: [ get_tag ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      # Step 1: checkout code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Step 2: login to GCHR
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Step 3: Build and push the Docker image
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: . # Build context (root directory, adjust if Dockerfile is elsewhere)
+          file: ./Dockerfile # Path to Dockerfile
+          push: ${{ github.event_name != 'pull_request' }} # Only push on push events, not PRs
+          tags: |
+            ghcr.io/bsv-blockchain/go-chaintracks:${{ github.sha }}
+            ghcr.io/bsv-blockchain/go-chaintracks:${{ needs.get_tag.outputs.deployment_tag }}
+


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building and pushing Docker images to the GitHub Container Registry (GHCR). The workflow automates image building and tagging for both pushes and pull requests to the `master` branch, as well as for version tags. The workflow consists of two main jobs: one to determine the deployment tag and another to build and push the Docker image.

**CI/CD Automation:**

* Added `.github/workflows/build.yml` to automate Docker image building and pushing to GHCR on pushes, pull requests to `master`, and workflow dispatch events.
* Implemented a job to dynamically determine the deployment tag (`latest` for branches, tag name for releases) for use in image tagging.
* Configured the workflow to build the Docker image from the repository root and push it to GHCR with both the commit SHA and the deployment tag as image tags.
* Ensured secure login to GHCR using the `docker/login-action` and GitHub secrets.