### PR TITLE
Update genesis.go to use TTN network name

### DIFF
--- a/chainmanager/genesis.go
+++ b/chainmanager/genesis.go
@@ -66,7 +66,7 @@ func getGenesisHeader(network string) (*block.Header, error) {
 		data = genesisMainnet
 	case "test":
 		data = genesisTestnet
-	case "teratest":
+	case "ttn":
 		data = genesisTeratestnet
 	default:
 		return nil, fmt.Errorf("%w: %s", chaintracks.ErrUnknownNetwork, network)


### PR DESCRIPTION
This pull request updates the network identifier used in the genesis header selection logic. The main change is renaming the `"teratest"` network identifier to `"ttn"` for improved clarity and consistency.

Network identifier update:

* Changed the case label from `"teratest"` to `"ttn"` in the `getGenesisHeader` function, ensuring the correct genesis data is selected for the renamed network. (`chainmanager/genesis.go`)