### PR TITLE
Bump go-p2p-messagebus to v0.1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bsv-blockchain/go-chaintracks
 go 1.26.0
 
 require (
-	github.com/bsv-blockchain/go-p2p-message-bus v0.1.15
+	github.com/bsv-blockchain/go-p2p-message-bus v0.1.16
 	github.com/bsv-blockchain/go-sdk v1.2.21
 	github.com/bsv-blockchain/go-teranode-p2p-client v0.2.1
 	github.com/bsv-blockchain/teranode v0.14.3-beta-5

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/bsv-blockchain/go-chaincfg v1.5.6 h1:fjTngPQLG0Z9H3U/c8YVJKvr63gy4oqj
 github.com/bsv-blockchain/go-chaincfg v1.5.6/go.mod h1:uWYO61x0CwnChjh79/8hOpoa+OkBOzTw9NlbNMjqchE=
 github.com/bsv-blockchain/go-lockfree-queue v1.1.2 h1:KjW2TZ9Mewe9xjyf5SV0L5wFjjwJTD7v2yVoFvz4S+A=
 github.com/bsv-blockchain/go-lockfree-queue v1.1.2/go.mod h1:1ah9XaAKnXdZwoAAlBZCX+cd3mMRDTlxKIRY6tVsiOM=
-github.com/bsv-blockchain/go-p2p-message-bus v0.1.15 h1:Ju0F3QJt2CG5JWgHceV+r35MLXfp0cY//fumr7aPGWY=
-github.com/bsv-blockchain/go-p2p-message-bus v0.1.15/go.mod h1:/onH4GkmRhcYPT9e+89izcEtiS9whY3tr2A5LmRVjq4=
+github.com/bsv-blockchain/go-p2p-message-bus v0.1.16 h1:D9/peNU4qpHzwqn0sA8jSnXXJ1kbaEfvL12fA3QBiUM=
+github.com/bsv-blockchain/go-p2p-message-bus v0.1.16/go.mod h1:QAcF5azAyfoLYlmRXEWxkVYXdyluiANyCR5fe56TCtk=
 github.com/bsv-blockchain/go-safe-conversion v1.1.2 h1:otAM71jUp+rBvEaNjfLTxlBKNnMbdbvDoew7brwPg0k=
 github.com/bsv-blockchain/go-safe-conversion v1.1.2/go.mod h1:KwO5HkH9S11kppAm7SedJhgaJnZbUMYRZalSq9fxLHQ=
 github.com/bsv-blockchain/go-sdk v1.2.21 h1:/EsUkdA3aj/7998q7Km2xW63tMO9Yox3IS5Guq9TrBk=


### PR DESCRIPTION
This pull request updates a dependency version in the `go.mod` file to ensure the project uses the latest features and fixes from an external library.

Dependency update:

* Upgraded `github.com/bsv-blockchain/go-p2p-message-bus` from version `v0.1.15` to `v0.1.16` in `go.mod`.